### PR TITLE
Align website core pages and services with brand strategy

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'About CorporateHub',
-  description: 'Learn about CorporateHub\'s mission, vision, and unique value proposition in optimizing Odoo for businesses.',
+  description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Founded by an OCA maintainer.',
 }
 
 export default function About() {
@@ -13,51 +13,51 @@ export default function About() {
       <h1 className="text-4xl font-bold mb-8 text-center">About CorporateHub</h1>
 
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-4">Our Mission</h2>
+        <h2 className="text-3xl font-bold mb-4">The Problem We Solve</h2>
         <p className="text-lg text-gray-600 mb-4">
-          At CorporateHub, our mission is to empower businesses by optimizing their operations through tailored Odoo solutions. We believe in the power of customized approaches that align perfectly with each client&apos;s unique identity and needs.
+          Most IT services agencies discover project losses months after delivery. Their timesheets live in one tool, accounting in another, and project tracking in a third. By the time someone exports the CSVs and builds a spreadsheet, the damage is done.
+        </p>
+        <p className="text-lg text-gray-600 mb-4">
+          CorporateHub exists to close that gap. We deploy integrated profitability and utilization visibility systems so agencies can see which projects earn and which lose &mdash; while there is still time to act.
         </p>
       </section>
 
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-4">Our Vision</h2>
+        <h2 className="text-3xl font-bold mb-4">How We Got Here</h2>
         <p className="text-lg text-gray-600 mb-4">
-          We envision a business world where companies of all sizes can harness the full potential of their operations, driven by seamlessly integrated and finely tuned Odoo systems. Our goal is to be the catalyst that transforms this vision into reality for our clients.
+          CorporateHub was founded by an OCA (Odoo Community Association) maintainer who built the professional services module suite to solve the same visibility problem at their own agency. That work grew into 349 merged OCA pull requests, 24 maintained modules on Odoo 18.0, and 5 maintainer-owned repositories.
+        </p>
+        <p className="text-lg text-gray-600 mb-4">
+          The modules cover time tracking, project roles, utilization analysis, timesheet approval workflows, and project profitability reporting &mdash; the building blocks agencies need to answer &quot;are we making money on this project?&quot; before the project ends.
         </p>
       </section>
 
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-4">Our Unique Value Proposition</h2>
+        <h2 className="text-3xl font-bold mb-4">What We Believe</h2>
         <ul className="list-disc list-inside text-lg text-gray-600 mb-4 space-y-2">
-          <li>Tailored solutions that respect and enhance your company&apos;s unique identity</li>
-          <li>Focus on tangible, measurable results that directly impact your bottom line</li>
-          <li>Attention to subtle business process details that make a big difference</li>
-          <li>Comprehensive services covering the entire Odoo lifecycle: from consultation to support</li>
-          <li>Deep expertise in Odoo customization and integration with other business tools</li>
+          <li><strong>Configuration first, customization second.</strong> 80% of the system is standard module configuration. Custom development is for the 20% that is genuinely unique to your workflow.</li>
+          <li><strong>Open-source by default.</strong> Every module we deploy is OCA-published and open-source licensed. No vendor lock-in, no proprietary forks.</li>
+          <li><strong>Show the work.</strong> Numbers over claims. Screenshots over promises. If we say deployment takes 1&ndash;3 weeks, we mean it &mdash; and we will show you why.</li>
         </ul>
       </section>
 
       <section className="mb-16">
         <h2 className="text-3xl font-bold mb-4">Our Approach</h2>
         <p className="text-lg text-gray-600 mb-4">
-          We believe that one size doesn&apos;t fit all when it comes to business solutions. Our approach is rooted in understanding the intricacies of your business, identifying areas for improvement, and implementing customized Odoo solutions that drive real, measurable results. We work closely with our clients, ensuring that every step of the process aligns with their goals and vision.
+          We deploy integrated time-tracking, project profitability, and utilization systems in 1&ndash;3 weeks for agencies of 10&ndash;30 people. The difference: we wrote the modules. You get the author, not someone configuring someone else&apos;s software.
+        </p>
+        <p className="text-lg text-gray-600 mb-4">
+          When something needs fixing or extending, we do not file a ticket upstream &mdash; we write the code and publish the fix to the OCA for everyone.
         </p>
       </section>
 
       <section className="text-center">
-        <h2 className="text-3xl font-bold mb-4">Ready to Transform Your Business?</h2>
-        <p className="text-xl text-gray-600 mb-8">Let&apos;s discuss how CorporateHub can help optimize your operations with tailored Odoo solutions.</p>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Agency</h2>
+        <p className="text-xl text-gray-600 mb-8">15-minute call to assess whether your current tools give you the project-level visibility you need.</p>
         <Button asChild size="lg">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Schedule a Consultation</Link>
         </Button>
       </section>
-
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </div>
   )
 }
-

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -39,7 +39,7 @@ const Footer = () => {
           </div>
           <div>
             <h4 className={`text-md ${commonStyles.heading} mb-4`}>
-              <Link href="/case-studies" className={`${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Case Studies</Link>
+              <Link href="/case-studies" className={`${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Our Work</Link>
             </h4>
             <ul className="space-y-2">
               <li><Link href="/case-studies/manufacturing-erp-optimization" className={`text-sm ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Manufacturing ERP Optimization</Link></li>

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -81,7 +81,7 @@ const Header = () => {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <Link href="/case-studies" className={`text-sm font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark} h-auto`}>Case Studies</Link>
+            <Link href="/case-studies" className={`text-sm font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark} h-auto`}>Our Work</Link>
             <div className="hidden md:flex items-center space-x-4">
               <Button asChild>
                 <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Schedule a Consultation</Link>
@@ -103,7 +103,7 @@ const Header = () => {
             <Link href="/about" className={`block px-3 py-2 text-base font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>About Us</Link>
             <Link href="/services" className={`block px-3 py-2 text-base font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Services</Link>
             <Link href="/solutions" className={`block px-3 py-2 text-base font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Solutions</Link>
-            <Link href="/case-studies" className={`block px-3 py-2 text-base font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Case Studies</Link>
+            <Link href="/case-studies" className={`block px-3 py-2 text-base font-medium ${commonStyles.link} ${commonStyles.linkLight} ${commonStyles.linkDark}`}>Our Work</Link>
           </nav>
           <div className="px-4 py-3 flex justify-between items-center">
             <Button asChild className="w-full mr-2">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,8 @@ import { ThemeProvider } from './components/theme-provider'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'CorporateHub® - Making business run smoother',
-  description: 'CorporateHub® offers consultation, training, tuning, data sync & migration, deployment, and support services for businesses using Odoo.',
+  title: 'CorporateHub\u00ae \u2014 Your profitability, visible.',
+  description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
   metadataBase: new URL('https://corporatehub.eu'),
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from './components/theme-provider'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'CorporateHub\u00ae \u2014 Your profitability, visible.',
+  title: 'CorporateHub\u00ae \u2014 Your agency\u2019s pulse.',
   description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
   metadataBase: new URL('https://corporatehub.eu'),
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,8 +26,7 @@ export default function Home() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         <section className="text-center mb-12 md:mb-16">
           <h1 className={`text-8xl md:text-7xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-16 md:mb-12`}>Your agency&apos;s pulse.</h1>
-          <p className={`text-xl md:text-2xl ${commonStyles.text} mb-6 md:mb-4`}>Not your accountant&apos;s surprise.</p>
-          <p className={`text-lg md:text-xl ${commonStyles.text} mb-24 md:mb-16 opacity-70`}>Real-time project profitability and utilization for IT services agencies.</p>
+          <p className={`text-xl md:text-2xl ${commonStyles.text} mb-24 md:mb-16`}>Real-time project profitability and utilization for IT services agencies.</p>
           <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
             <Button asChild size="lg">
               <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Schedule a Consultation</Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,15 +6,15 @@ import { commonStyles } from './styles/common'
 import { generateStructuredData } from './utils/structuredData'
 
 export const metadata: Metadata = {
-  title: 'CorporateHub - Making business run smoother',
-  description: 'CorporateHub offers consultation, training, tuning, data sync & migration, deployment, and support services for businesses using Odoo.',
+  title: 'CorporateHub \u2014 Your profitability, visible.',
+  description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
 }
 
 export default function Home() {
   const structuredData = generateStructuredData({
     '@type': 'WebSite',
-    name: 'CorporateHub - Making business run smoother',
-    description: 'CorporateHub offers consultation, training, tuning, data sync & migration, deployment, and support services for businesses using Odoo.',
+    name: 'CorporateHub \u2014 Your profitability, visible.',
+    description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
   });
 
   return (
@@ -25,8 +25,8 @@ export default function Home() {
       />
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         <section className="text-center mb-12 md:mb-16">
-          <h1 className={`text-8xl md:text-7xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-16 md:mb-12`}>Making business run smoother</h1>
-          <h1 className={`text-4xl md:text-5xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-24 md:mb-16`}>One step at a time</h1>
+          <h1 className={`text-8xl md:text-7xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-16 md:mb-12`}>Your profitability, visible.</h1>
+          <p className={`text-xl md:text-2xl ${commonStyles.text} mb-24 md:mb-16`}>Integrated time tracking, utilization, and project profitability for services firms.</p>
           <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
             <Button asChild size="lg">
               <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Schedule a Consultation</Link>
@@ -41,12 +41,12 @@ export default function Home() {
           <h2 className="text-2xl md:text-3xl font-bold mb-6 md:mb-8 text-center">Our Services</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
             {[
-              { title: "Consultation", description: "Strategic guidance for business optimization.", link: "/services/consultation" },
-              { title: "Training", description: "Hands-on Odoo training tailored to teams.", link: "/services/training" },
-              { title: "Tuning", description: "Tweaking Odoo to your business.", link: "/services/tuning" },
-              { title: "Data Sync & Migration", description: "Integration with tools like HubSpot, Jira, and others.", link: "/services/data-sync-migration" },
-              { title: "Deployment", description: "Smooth implementation of Odoo solutions.", link: "/services/deployment" },
-              { title: "Support", description: "Ongoing assistance for your Odoo environment.", link: "/services/support" },
+              { title: "Consultation", description: "We assess your current tool stack and map where profitability visibility breaks down.", link: "/services/consultation" },
+              { title: "Training", description: "Your team learns the system they will actually use \u2014 timesheet entry, project tracking, and the reports that matter.", link: "/services/training" },
+              { title: "Tuning", description: "We configure timesheet workflows, approval chains, and project profitability reports to match how you actually work.", link: "/services/tuning" },
+              { title: "Data Sync & Migration", description: "Your historical data from Harvest, Toggl, Xero, or Jira migrated into one system.", link: "/services/data-sync-migration" },
+              { title: "Deployment", description: "Full deployment of the professional services module suite. Typically 1\u20133 weeks for a 10\u201330 person agency.", link: "/services/deployment" },
+              { title: "Support", description: "Post-deployment support from the source \u2014 we maintain the OCA modules your system runs on.", link: "/services/support" },
             ].map((service, index) => (
               <Link href={service.link} key={index} className="block group">
                 <div className="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-6 rounded-lg shadow-md h-full transition-all duration-300 ease-in-out group-hover:shadow-lg group-hover:scale-105 group-hover:bg-gray-50 dark:group-hover:bg-gray-700">
@@ -61,29 +61,29 @@ export default function Home() {
         </section>
 
         <section className="mb-12 md:mb-16">
-          <h2 className={`text-2xl md:text-3xl font-bold mb-6 md:mb-8 text-center ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Why Choose CorporateHub?</h2>
+          <h2 className={`text-2xl md:text-3xl font-bold mb-6 md:mb-8 text-center ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Why CorporateHub</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
             <Card>
               <CardContent className="pt-6">
-                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>One-Size-Doesn&apos;t-Fit-All Approach</h3>
+                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>You get the author, not a re-seller</h3>
                 <p className={commonStyles.text}>
-                  We understand that every business is unique. Our solutions are tailored to align perfectly with your specific workflows and business identity.
+                  24 OCA modules on Odoo 18.0, including the professional services timesheet suite. When something needs fixing, I write the code.
                 </p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="pt-6">
-                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Focus on Tangible Results</h3>
+                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Deployed in weeks, not months</h3>
                 <p className={commonStyles.text}>
-                  We prioritize delivering measurable improvements that drive real business value, ensuring every change contributes to your growth.
+                  Configuration-first: 80% standard module configuration, 20% custom to your workflow. Typical timeline: 1&ndash;3 weeks for a 10&ndash;30 person agency.
                 </p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="pt-6">
-                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Expertise You Can Trust</h3>
+                <h3 className={`text-xl font-semibold mb-3 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Open-source, no lock-in</h3>
                 <p className={commonStyles.text}>
-                  With our deep knowledge of Odoo and integration processes, we provide reliable solutions that stand the test of time and scale with your business.
+                  Every module is OCA-published and open-source licensed. If you outgrow CorporateHub, your system stays. Your data stays.
                 </p>
               </CardContent>
             </Card>
@@ -91,8 +91,8 @@ export default function Home() {
         </section>
 
         <section className="text-center rounded-lg p-6">
-          <h2 className={`text-2xl md:text-3xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>Ready to optimize your business?</h2>
-          <p className={`text-lg md:text-xl ${commonStyles.text} mb-6 md:mb-8`}>Let&apos;s discuss how CorporateHub can help streamline your operations.</p>
+          <h2 className={`text-2xl md:text-3xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark}`}>See what profitability visibility looks like</h2>
+          <p className={`text-lg md:text-xl ${commonStyles.text} mb-6 md:mb-8`}>15-minute call to assess whether your current tools give you the project-level visibility you need.</p>
           <Button asChild size="lg">
             <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Get Started</Link>
           </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,14 +6,14 @@ import { commonStyles } from './styles/common'
 import { generateStructuredData } from './utils/structuredData'
 
 export const metadata: Metadata = {
-  title: 'CorporateHub \u2014 Your profitability, visible.',
+  title: 'CorporateHub \u2014 Your agency\u2019s pulse.',
   description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
 }
 
 export default function Home() {
   const structuredData = generateStructuredData({
     '@type': 'WebSite',
-    name: 'CorporateHub \u2014 Your profitability, visible.',
+    name: 'CorporateHub \u2014 Your agency\u2019s pulse.',
     description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
   });
 
@@ -25,8 +25,9 @@ export default function Home() {
       />
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
         <section className="text-center mb-12 md:mb-16">
-          <h1 className={`text-8xl md:text-7xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-16 md:mb-12`}>Your profitability, visible.</h1>
-          <p className={`text-xl md:text-2xl ${commonStyles.text} mb-24 md:mb-16`}>Integrated time tracking, utilization, and project profitability for services firms.</p>
+          <h1 className={`text-8xl md:text-7xl font-bold mb-4 ${commonStyles.headingLight} ${commonStyles.headingDark} mb-16 md:mb-12`}>Your agency&apos;s pulse.</h1>
+          <p className={`text-xl md:text-2xl ${commonStyles.text} mb-6 md:mb-4`}>Not your accountant&apos;s surprise.</p>
+          <p className={`text-lg md:text-xl ${commonStyles.text} mb-24 md:mb-16 opacity-70`}>Real-time project profitability and utilization for IT services agencies.</p>
           <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-4">
             <Button asChild size="lg">
               <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">Schedule a Consultation</Link>

--- a/app/services/consultation/page.tsx
+++ b/app/services/consultation/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Consultation Services - CorporateHub',
-  description: 'Unlock your business potential with CorporateHub\'s tailored Odoo consultation services. We provide strategic guidance for optimizing your operations and achieving tangible results.',
+  description: 'We assess your current tool stack and map where profitability visibility breaks down. Outcome: a deployment plan with scope, timeline, and cost.',
 }
 
 export default function ConsultationService() {
@@ -18,7 +18,7 @@ export default function ConsultationService() {
           Consultation Services
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          Unlock Your Business Potential with Tailored Odoo Expertise
+          We assess your current tool stack and map where profitability visibility breaks down
         </p>
       </header>
 
@@ -31,29 +31,29 @@ export default function ConsultationService() {
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub</h2>
         <div className="grid md:grid-cols-3 gap-6">
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">One-Size-Doesn&apos;t-Fit-All Approach</h3>
+              <h3 className="text-xl font-semibold mb-3">You get the author, not a re-seller</h3>
               <p className="text-muted-foreground">
-                Your business processes are as unique as your business identity. We don&apos;t believe in cookie-cutter solutions. Instead, we dive deep into your operations to provide personalized recommendations that drive real, measurable results.
+                24 OCA modules on Odoo 18.0, including the professional services timesheet suite. When something needs fixing, I write the code.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Tangible, Incremental Improvements</h3>
+              <h3 className="text-xl font-semibold mb-3">Deployed in weeks, not months</h3>
               <p className="text-muted-foreground">
-                Change doesn&apos;t have to be overwhelming. Our team focuses on practical, step-by-step enhancements that empower your business without disrupting day-to-day operations.
+                Configuration-first: 80% standard module configuration, 20% custom to your workflow. Typical timeline: 1&ndash;3 weeks for a 10&ndash;30 person agency.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Proven Expertise</h3>
+              <h3 className="text-xl font-semibold mb-3">Open-source, no lock-in</h3>
               <p className="text-muted-foreground">
-                With years of experience in Odoo customization, migration, and integration, we bring a wealth of knowledge to the table. You&apos;ll benefit from expert insights tailored to your specific industry and challenges.
+                Every module is OCA-published and open-source licensed. If you outgrow CorporateHub, your system stays. Your data stays.
               </p>
             </CardContent>
           </Card>
@@ -130,42 +130,11 @@ export default function ConsultationService() {
         </div>
       </section>
 
-      {/* Success Stories Section */}
-      <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Success Stories</h2>
-        <div className="grid md:grid-cols-2 gap-6">
-          <Card>
-            <CardContent className="pt-6">
-              <blockquote className="space-y-2">
-                <p className="text-muted-foreground">
-                  &quot;CorporateHub helped us streamline our operations and integrate Odoo seamlessly with our existing tools. Their personalized approach and clear recommendations were game-changers for our business.&quot;
-                </p>
-                <footer className="text-sm font-semibold">
-                  &mdash; Sarah T., Operations Manager
-                </footer>
-              </blockquote>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <blockquote className="space-y-2">
-                <p className="text-muted-foreground">
-                  &quot;The team at CorporateHub took the time to understand our unique challenges and provided solutions that really worked. Their consultation was invaluable.&quot;
-                </p>
-                <footer className="text-sm font-semibold">
-                  &mdash; James L., CEO
-                </footer>
-              </blockquote>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Let&apos;s Get Started</h2>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Agency</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Ready to make your business run smoother? Contact CorporateHub today for a free initial consultation. Let&apos;s explore how Odoo can be tuned to meet your needs and unlock your full potential.
+          15-minute call to assess whether your current tools give you the project-level visibility you need.
         </p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
@@ -175,11 +144,6 @@ export default function ConsultationService() {
         </Button>
       </section>
 
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/services/data-sync-migration/page.tsx
+++ b/app/services/data-sync-migration/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Data Sync & Migration Services - CorporateHub',
-  description: 'Seamlessly integrate your business tools with CorporateHub\'s data sync and migration services for Odoo. We ensure smooth transitions and efficient data flow between systems.',
+  description: 'Your historical data from Harvest, Toggl, Xero, or Jira migrated into one system. No more exporting CSVs to build a profitability picture.',
 }
 
 export default function DataSyncMigrationService() {
@@ -18,41 +18,41 @@ export default function DataSyncMigrationService() {
           Data Sync & Migration Services
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          Seamless Integration for Business Growth
+          Your historical data from Harvest, Toggl, Xero, or Jira migrated into one system
         </p>
       </header>
 
       <section className="mb-16">
         <p className="text-lg text-muted-foreground mb-8">
-          In today&apos;s fast-paced business environment, ensuring your systems work together without hiccups is crucial. At CorporateHub, we specialize in making your data transition and synchronization processes smooth, efficient, and tailored to your unique business needs.
+          Most IT services agencies have timesheet data in one tool, accounting in another, and project tracking in a third. We bring it all into one system so you can see project profitability without exporting CSVs.
         </p>
       </section>
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub</h2>
         <div className="grid md:grid-cols-3 gap-6">
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">One-Size-Doesn&apos;t-Fit-All Approach</h3>
+              <h3 className="text-xl font-semibold mb-3">You get the author, not a re-seller</h3>
               <p className="text-muted-foreground">
-                We recognize that no two businesses are alike. That&apos;s why we customize every data sync and migration project to suit your specific requirements.
+                24 OCA modules on Odoo 18.0, including the professional services timesheet suite. When something needs fixing, I write the code.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Focus on Incremental Results</h3>
+              <h3 className="text-xl font-semibold mb-3">Deployed in weeks, not months</h3>
               <p className="text-muted-foreground">
-                Whether it&apos;s syncing two platforms or a complete migration, we ensure every step delivers measurable value.
+                Configuration-first: 80% standard module configuration, 20% custom to your workflow. Typical timeline: 1&ndash;3 weeks for a 10&ndash;30 person agency.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Preserving Your Business Identity</h3>
+              <h3 className="text-xl font-semibold mb-3">Open-source, no lock-in</h3>
               <p className="text-muted-foreground">
-                Your business processes are unique, and so are the nuances that make them work. We ensure every subtle detail is carried forward flawlessly.
+                Every module is OCA-published and open-source licensed. If you outgrow CorporateHub, your system stays. Your data stays.
               </p>
             </CardContent>
           </Card>
@@ -171,9 +171,9 @@ export default function DataSyncMigrationService() {
 
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Ready to Streamline Your Business?</h2>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Agency</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Let&apos;s make your data work for you. Contact CorporateHub today to learn how our Data Sync & Migration services can enhance your business processes and drive growth.
+          15-minute call to assess whether your current tools give you the project-level visibility you need.
         </p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
@@ -183,11 +183,6 @@ export default function DataSyncMigrationService() {
         </Button>
       </section>
 
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/services/deployment/page.tsx
+++ b/app/services/deployment/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Deployment Services - CorporateHub',
-  description: 'Ensure a smooth Odoo implementation with CorporateHub\'s expert deployment services. We handle the technical complexities, allowing you to focus on your business growth.',
+  description: 'Full deployment of the professional services module suite: time tracking, utilization, project profitability, and role-based costing. Typically 1\u20133 weeks for a 10\u201330 person agency.',
 }
 
 export default function DeploymentService() {
@@ -18,49 +18,49 @@ export default function DeploymentService() {
           Deployment Services
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          Smooth, Stress-Free Odoo Rollout
+          Full deployment of the professional services module suite. Typically 1&ndash;3 weeks for a 10&ndash;30 person agency.
         </p>
       </header>
 
       <section className="mb-16">
         <p className="text-lg text-muted-foreground mb-8">
-          At <strong>CorporateHub</strong>, we understand that deploying Odoo isn&apos;t just about getting the software up and running; it&apos;s about making it work seamlessly for your business from day one. Whether you&apos;re starting fresh or transitioning from a legacy system, our deployment services ensure a smooth and reliable rollout tailored to your needs.
+          We deploy integrated time-tracking, utilization, project profitability, and role-based costing modules for IT services agencies. The difference: we wrote the modules. You get the author, not someone configuring someone else&apos;s software.
         </p>
       </section>
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub for Odoo Deployment?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub for Deployment</h2>
         <div className="grid md:grid-cols-2 gap-6">
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Tailored Deployment Strategies</h3>
+              <h3 className="text-xl font-semibold mb-3">You get the author, not a re-seller</h3>
               <p className="text-muted-foreground">
-                We don&apos;t believe in one-size-fits-all. Each business is unique, and so is its deployment journey. Our team analyzes your workflows, systems, and goals to craft a customized deployment strategy.
+                24 OCA modules on Odoo 18.0, including the professional services timesheet suite. When something needs fixing or extending, I write the code.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">End-to-End Support</h3>
+              <h3 className="text-xl font-semibold mb-3">Configuration-first methodology</h3>
               <p className="text-muted-foreground">
-                From initial system configuration to the final rollout, we&apos;re by your side. We&apos;ll handle the technical complexities so you can focus on running your business.
+                80% of the system is standard module configuration, 20% is custom to your workflow. This is why deployment takes weeks, not months.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Minimized Downtime</h3>
+              <h3 className="text-xl font-semibold mb-3">Deployed in weeks, not months</h3>
               <p className="text-muted-foreground">
-                We know time is money. Our deployment process is designed to minimize disruption to your operations, ensuring a quick and efficient transition.
+                Typical timeline: 1&ndash;3 weeks remote deployment for a 10&ndash;30 person agency. We configure, migrate, train, and go live.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Expertise You Can Trust</h3>
+              <h3 className="text-xl font-semibold mb-3">Open-source, no lock-in</h3>
               <p className="text-muted-foreground">
-                With years of experience deploying Odoo for businesses across industries, we&apos;ve mastered the art of delivering seamless implementations.
+                Every module is OCA-published and open-source licensed. If you outgrow CorporateHub, your system stays. Your data stays. Another Odoo partner can pick up where we left off.
               </p>
             </CardContent>
           </Card>
@@ -163,9 +163,9 @@ export default function DeploymentService() {
 
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Start Your Odoo Journey with Confidence</h2>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Agency</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Ready to make your Odoo deployment a success? Let CorporateHub guide you every step of the way. Contact us today to discuss your needs and discover how we can make your Odoo rollout smooth, efficient, and stress-free.
+          15-minute call to assess whether your current tools give you the project-level visibility you need.
         </p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
@@ -175,11 +175,6 @@ export default function DeploymentService() {
         </Button>
       </section>
 
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -7,39 +7,39 @@ import { generateStructuredData } from '../utils/structuredData'
 
 export const metadata: Metadata = {
   title: 'Our Services - CorporateHub',
-  description: 'Discover CorporateHub\'s comprehensive Odoo services including consultation, training, tuning, data sync & migration, deployment, and support. We help optimize your business operations with tailored solutions.',
+  description: 'CorporateHub deploys profitability and utilization visibility systems for IT services agencies. Consultation, training, tuning, migration, deployment, and support.',
 }
 
 const services = [
   {
     title: "Consultation",
-    description: "Discover how our consultation services helped a manufacturing business optimize its ERP system for smoother operations.",
-    link: "/case-studies/manufacturing-erp-optimization"
+    description: "We assess your current tool stack and map where profitability visibility breaks down. Outcome: a deployment plan with scope, timeline, and cost.",
+    link: "/services/consultation"
   },
   {
     title: "Training",
-    description: "Learn how our training programs empowered a retail team to boost productivity and upskill effectively.",
-    link: "/case-studies/retail-workforce-upskilling"
+    description: "Your team learns the system they will actually use \u2014 timesheet entry, project tracking, and the reports that show whether projects earn or lose.",
+    link: "/services/training"
   },
   {
     title: "Tuning",
-    description: "See how our tuning services enabled precise billing solutions tailored for project-based businesses.",
+    description: "Your Odoo is running but not showing what matters. We configure timesheet workflows, approval chains, and project profitability reports to match how you actually work.",
     link: "/services/tuning"
   },
   {
     title: "Data Sync & Migration",
-    description: "Explore how we seamlessly connected HubSpot and Odoo to enhance data flow and efficiency.",
-    link: "/solutions/hubspot-odoo-sync-migration"
+    description: "Your historical data from Harvest, Toggl, Xero, or Jira migrated into one system. No more exporting CSVs to build a profitability picture.",
+    link: "/services/data-sync-migration"
   },
   {
     title: "Deployment",
-    description: "Find out how our deployment services supported a successful Odoo launch for an e-commerce business.",
-    link: "/case-studies/ecommerce-odoo-deployment"
+    description: "Full deployment of the professional services module suite: time tracking, utilization, project profitability, and role-based costing. Typically 1\u20133 weeks for a 10\u201330 person agency.",
+    link: "/services/deployment"
   },
   {
     title: "Support",
-    description: "Learn how ongoing support services helped a business tackle ERP challenges before they became issues.",
-    link: "/case-studies/proactive-support-erp-challenges"
+    description: "Post-deployment support for configuration changes, new modules, and version upgrades. We maintain the OCA modules your system runs on, so support comes from the source.",
+    link: "/services/support"
   }
 ]
 
@@ -53,7 +53,7 @@ export default function ServicesPage() {
         '@type': 'Service',
         name: service.title,
         description: service.description,
-        url: `https://corporatehub.com${service.link}`
+        url: `https://corporatehub.eu${service.link}`
       }
     }))
   });
@@ -70,7 +70,7 @@ export default function ServicesPage() {
             Our Services
           </h1>
           <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
-            Discover how CorporateHub can optimize your business operations with our comprehensive Odoo services.
+            We deploy profitability and utilization visibility systems for IT services agencies. Here is what that looks like.
           </p>
         </header>
 
@@ -139,9 +139,9 @@ export default function ServicesPage() {
         </section>
 
         <section className="text-center rounded-lg px-4 py-8 md:py-12 sm:px-6 lg:px-8">
-          <h2 className="text-2xl md:text-3xl font-bold mb-4">Need a Customized Solution?</h2>
+          <h2 className="text-2xl md:text-3xl font-bold mb-4">Ready to see what this looks like for your agency?</h2>
           <p className="text-lg md:text-xl text-muted-foreground mb-6 md:mb-8 max-w-2xl mx-auto">
-            We specialize in tailoring our services to meet your unique business needs. Let&apos;s discuss how we can optimize your Odoo experience.
+            15-minute call to assess whether your current tools give you the project-level visibility you need.
           </p>
           <Button asChild size="lg" className="gap-2">
             <Link href="/contact">
@@ -151,11 +151,6 @@ export default function ServicesPage() {
           </Button>
         </section>
 
-        <footer className="text-center mt-16">
-          <p className="text-lg font-semibold text-primary">
-            CorporateHub – Making Business Run Smoother, One Step at a Time
-          </p>
-        </footer>
       </div>
     </>
   )

--- a/app/services/support/page.tsx
+++ b/app/services/support/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Support Services - CorporateHub',
-  description: 'Get reliable, ongoing assistance for your Odoo system with CorporateHub\'s support services. We ensure your Odoo environment stays optimized and aligned with your evolving business needs.',
+  description: 'Post-deployment support for configuration changes, new modules, and version upgrades. We maintain the OCA modules your system runs on, so support comes from the source.',
 }
 
 export default function SupportService() {
@@ -18,7 +18,7 @@ export default function SupportService() {
           Support Services
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          Making Business Run Smoother – One Step at a Time
+          Post-deployment support from the source &mdash; we maintain the OCA modules your system runs on
         </p>
       </header>
 
@@ -30,11 +30,11 @@ export default function SupportService() {
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub Support?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub for Support</h2>
         <Card>
           <CardContent className="pt-6">
             <p className="text-lg text-muted-foreground">
-              With our one-size-doesn&apos;t-fit-all approach, we focus on delivering support that addresses the unique challenges of your business. From quick troubleshooting to strategic optimizations, our support solutions are designed to handle the subtleties that define your business processes.
+              We maintain 24 OCA modules on Odoo 18.0, including the professional services timesheet suite your system runs on. When you need a configuration change, a new module, or a version upgrade, support comes from the people who wrote the code &mdash; not a re-seller reading documentation.
             </p>
           </CardContent>
         </Card>
@@ -141,11 +141,10 @@ export default function SupportService() {
 
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Let&apos;s Simplify Your Odoo Experience</h2>
+        <h2 className="text-3xl font-bold mb-4">See What Support From the Source Looks Like</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Whether you&apos;re resolving a critical issue or looking for continuous improvements, our support team is here to help. With CorporateHub, your business runs smoother – one step at a time.
+          15-minute call to assess whether your current tools give you the project-level visibility you need.
         </p>
-        <p className="text-2xl font-bold mb-8">Ready for hassle-free support?</p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
             Contact Us Today
@@ -154,11 +153,6 @@ export default function SupportService() {
         </Button>
       </section>
 
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/services/training/page.tsx
+++ b/app/services/training/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Training Services - CorporateHub',
-  description: 'Empower your team with CorporateHub\'s customized Odoo training services. Our hands-on approach ensures your staff can maximize the potential of your Odoo platform.',
+  description: 'Your team learns the system they will actually use \u2014 timesheet entry, project tracking, and the reports that show whether projects earn or lose.',
 }
 
 export default function TrainingService() {
@@ -15,38 +15,38 @@ export default function TrainingService() {
       {/* Hero Section */}
       <header className="text-center mb-16">
         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl mb-4">
-          Training for Odoo: Empower Your Team to Excel
+          Training Services
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          At CorporateHub, we believe that software is only as good as the people using it. Our Odoo training services are tailored to equip your team with the skills and confidence they need to maximize the potential of your Odoo platform.
+          Your team learns the system they will actually use &mdash; timesheet entry, project tracking, and the reports that show whether projects earn or lose.
         </p>
       </header>
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub for Odoo Training?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub for Training</h2>
         <div className="grid md:grid-cols-3 gap-6">
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">One-size-doesn&apos;t-fit-all approach</h3>
+              <h3 className="text-xl font-semibold mb-3">You get the author, not a re-seller</h3>
               <p className="text-muted-foreground">
-                We understand that every business is unique. Our training programs are designed to align with your specific workflows, ensuring that your team learns what matters most to your operations.
+                24 OCA modules on Odoo 18.0, including the professional services timesheet suite. When something needs fixing, I write the code.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Hands-on, practical learning</h3>
+              <h3 className="text-xl font-semibold mb-3">Deployed in weeks, not months</h3>
               <p className="text-muted-foreground">
-                Forget generic tutorials. We focus on practical, real-world scenarios that your team encounters daily, making the training sessions relevant and immediately actionable.
+                Configuration-first: 80% standard module configuration, 20% custom to your workflow. Typical timeline: 1&ndash;3 weeks for a 10&ndash;30 person agency.
               </p>
             </CardContent>
           </Card>
           <Card>
             <CardContent className="pt-6">
-              <h3 className="text-xl font-semibold mb-3">Incremental results that matter</h3>
+              <h3 className="text-xl font-semibold mb-3">Open-source, no lock-in</h3>
               <p className="text-muted-foreground">
-                We prioritize tangible outcomes, breaking complex topics into manageable steps that help your team build their expertise progressively.
+                Every module is OCA-published and open-source licensed. If you outgrow CorporateHub, your system stays. Your data stays.
               </p>
             </CardContent>
           </Card>
@@ -143,7 +143,7 @@ export default function TrainingService() {
             },
             {
               title: "Minimize Errors",
-              description: "Proper training reduces mistakes, ensuring smoother operations."
+              description: "Proper training reduces mistakes and keeps your data accurate from day one."
             },
             {
               title: "Enhance ROI",
@@ -165,9 +165,9 @@ export default function TrainingService() {
 
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Ready to Empower Your Team?</h2>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Team</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Let&apos;s make your Odoo experience seamless and impactful. Contact CorporateHub today to discuss your training needs and start making business run smoother—one step at a time.
+          15-minute call to assess whether your current tools give you the project-level visibility you need.
         </p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
@@ -177,11 +177,6 @@ export default function TrainingService() {
         </Button>
       </section>
 
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/services/tuning/page.tsx
+++ b/app/services/tuning/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Tuning Services - CorporateHub',
-  description: 'Optimize your Odoo experience with CorporateHub\'s expert tuning services. We fine-tune your system for peak performance, focusing on HR, Project, Accounting, and UX enhancements.',
+  description: 'Your Odoo is running but not showing what matters. We configure timesheet workflows, approval chains, and project profitability reports to match how you actually work.',
 }
 
 export default function TuningService() {
@@ -18,17 +18,17 @@ export default function TuningService() {
           Tuning Services for Odoo
         </h1>
         <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-          At CorporateHub, we believe that Odoo should work for your business, not the other way around. Our tuning services are designed to adapt and refine your Odoo platform to match the unique needs of your business processes.
+          Your Odoo is running but not showing what matters. We configure timesheet workflows, approval chains, and project profitability reports to match how you actually work.
         </p>
       </header>
 
       {/* Why Choose Section */}
       <section className="mb-16">
-        <h2 className="text-3xl font-bold mb-8">Why Choose CorporateHub for Odoo Tuning?</h2>
+        <h2 className="text-3xl font-bold mb-8">Why CorporateHub for Tuning</h2>
         <Card>
           <CardContent className="pt-6">
             <p className="text-lg text-muted-foreground">
-              We apply a one-size-doesn&apos;t-fit-all philosophy, focusing on tangible, incremental improvements that make a difference. By addressing subtle details and aligning Odoo with your business identity, we deliver a solution that truly fits.
+              We maintain 24 OCA modules on Odoo 18.0, including the professional services timesheet suite your system will run on. When a configuration change requires a module fix, we write the code &mdash; we do not file a ticket. Configuration-first methodology: 80% of the system is standard module configuration, 20% is custom to your workflow.
             </p>
           </CardContent>
         </Card>
@@ -145,9 +145,9 @@ export default function TuningService() {
 
       {/* CTA Section */}
       <section className="text-center px-4 py-12 sm:px-6 lg:px-8">
-        <h2 className="text-3xl font-bold mb-4">Let&apos;s Make Your Odoo Better</h2>
+        <h2 className="text-3xl font-bold mb-4">See What This Looks Like for Your Agency</h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Your business is unique, and your Odoo system should reflect that. Whether you need a simple enhancement or a complete overhaul, CorporateHub is here to help. Contact us today to explore how we can tune Odoo to meet your goals.
+          15-minute call to assess whether your current Odoo configuration gives you the project-level visibility you need.
         </p>
         <Button asChild size="lg" className="gap-2">
           <Link href="https://cal.com/alexey-pelykh/consultation" target="_blank">
@@ -156,11 +156,6 @@ export default function TuningService() {
           </Link>
         </Button>
       </section>
-      <footer className="text-center mt-16">
-        <p className="text-lg font-semibold text-primary">
-          CorporateHub – Making Business Run Smoother, One Step at a Time
-        </p>
-      </footer>
     </article>
   )
 }

--- a/app/utils/structuredData.ts
+++ b/app/utils/structuredData.ts
@@ -12,7 +12,7 @@ export function generateStructuredData(data: Partial<StructuredData>): string {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: 'CorporateHub®',
-    description: 'CorporateHub® offers consultation, training, tuning, data sync & migration, deployment, and support services for businesses using Odoo.',
+    description: 'Odoo consulting partner specializing in profitability and utilization visibility for IT services agencies. Built by an OCA maintainer with 24 modules on Odoo 18.0.',
     url: 'https://corporatehub.eu',
     ...data
   };


### PR DESCRIPTION
## Summary

- Replace old tagline "Making business run smoother" with "Your profitability, visible." across 13 files
- Rewrite About page with problem-first narrative, OCA credentials, and brand values
- Replace generic "Why Choose" sections with evidence-based differentiators
- Update all 6 service descriptions to beachhead-specific messaging per `brand/messaging.md` Section 6
- Remove fabricated testimonials from consultation page
- Remove footer tagline blocks from all service pages
- Fix `corporatehub.com` to `.eu` domain reference
- Rename "Case Studies" nav label to "Our Work" in header and footer

## Verification

- `npm run build` passes (34 pages compiled)
- Grep for "smoother"/"step at a time" returns zero hits in in-scope files
- Grep for "corporatehub.com" returns zero hits

## References

- Brand source: `corporatehub/hq` — `brand/messaging.md`, `brand/voice.md`
- Tracking issue: corporatehub/hq#13

## Out of scope

Solutions pages (4 files) and case studies pages (14 files) still contain old messaging — to be addressed in a follow-up issue per the original scope definition (Batch 3A + 3B only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)