### PR TITLE
Remove banned vocabulary from service detail sections

### DIFF
--- a/app/services/data-sync-migration/page.tsx
+++ b/app/services/data-sync-migration/page.tsx
@@ -81,7 +81,7 @@ export default function DataSyncMigrationService() {
                 <h3 className="text-xl font-semibold">HubSpot to Odoo Migration</h3>
               </div>
               <p className="text-muted-foreground">
-                Switching from HubSpot to Odoo? We make the transition seamless by migrating your data with accuracy and integrity, ensuring your workflows continue without disruption.
+                Switching from HubSpot to Odoo? We migrate your data with accuracy and integrity, ensuring your workflows continue without disruption.
               </p>
             </CardContent>
           </Card>
@@ -127,7 +127,7 @@ export default function DataSyncMigrationService() {
         <div className="grid md:grid-cols-3 lg:grid-cols-5 gap-6">
           {[
             { title: "Consultation", description: "We start by understanding your existing systems, processes, and pain points." },
-            { title: "Planning", description: "A detailed project roadmap ensures a seamless integration or migration." },
+            { title: "Planning", description: "A detailed project roadmap ensures a smooth integration or migration." },
             { title: "Execution", description: "Using proven tools and methodologies, we handle the technical aspects with precision." },
             { title: "Validation", description: "Rigorous testing ensures data accuracy and functionality." },
             { title: "Support", description: "Post-deployment support to address any challenges and fine-tune the solution." },
@@ -156,7 +156,7 @@ export default function DataSyncMigrationService() {
           {[
             { title: "Minimized Downtime", description: "We prioritize business continuity throughout the process." },
             { title: "Data Integrity", description: "No loss, duplication, or corruption of data during sync or migration." },
-            { title: "Custom Configurations", description: "Tailored solutions to fit your business processes." },
+            { title: "Custom Configurations", description: "Configurations built to match your specific business processes." },
             { title: "Expert Support", description: "Our team is available to assist you at every step." },
           ].map((benefit, index) => (
             <Card key={index}>

--- a/app/services/deployment/page.tsx
+++ b/app/services/deployment/page.tsx
@@ -111,7 +111,7 @@ export default function DeploymentService() {
                 <h3 className="text-xl font-semibold">Integration with Existing Systems</h3>
               </div>
               <p className="text-muted-foreground">
-                Need Odoo to work with other tools? We integrate Odoo seamlessly with platforms like HubSpot, Jira, Tempo Timesheets, and more to create a unified ecosystem.
+                Need Odoo to work with other tools? We connect Odoo with platforms like HubSpot, Jira, Tempo Timesheets, and more into one integrated system.
               </p>
             </CardContent>
           </Card>
@@ -133,7 +133,7 @@ export default function DeploymentService() {
                 <h3 className="text-xl font-semibold">Deployment and Go-Live</h3>
               </div>
               <p className="text-muted-foreground">
-                With all systems go, we execute the deployment plan, ensuring a seamless transition with minimal downtime.
+                With all systems go, we execute the deployment plan, ensuring a smooth transition with minimal downtime.
               </p>
             </CardContent>
           </Card>

--- a/app/services/support/page.tsx
+++ b/app/services/support/page.tsx
@@ -51,7 +51,7 @@ export default function SupportService() {
                 <h3 className="text-xl font-semibold">Ongoing Maintenance & Issue Resolution</h3>
               </div>
               <p className="text-muted-foreground mb-4">
-                Keep your Odoo environment running seamlessly. Our experts provide:
+                Keep your Odoo environment running without interruption. Our experts provide:
               </p>
               <ul className="list-disc list-inside space-y-2 text-muted-foreground">
                 <li>Proactive monitoring and updates</li>
@@ -88,7 +88,7 @@ export default function SupportService() {
               <ul className="list-disc list-inside space-y-2 text-muted-foreground">
                 <li>Tailored feature updates to meet business requirements</li>
                 <li>Expert advice on leveraging Odoo&apos;s capabilities</li>
-                <li>Seamless integration of third-party tools</li>
+                <li>Integration of third-party tools with your Odoo instance</li>
               </ul>
             </CardContent>
           </Card>
@@ -115,7 +115,7 @@ export default function SupportService() {
                 <h3 className="text-xl font-semibold">End-User Support & Training</h3>
               </div>
               <p className="text-muted-foreground mb-4">
-                Empower your team to get the most out of Odoo:
+                Help your team get the most out of Odoo:
               </p>
               <ul className="list-disc list-inside space-y-2 text-muted-foreground">
                 <li>Quick support for user queries</li>

--- a/app/services/training/page.tsx
+++ b/app/services/training/page.tsx
@@ -76,7 +76,7 @@ export default function TrainingService() {
             {
               icon: Shield,
               title: "Administrator Training",
-              description: "Empower your administrators with the knowledge they need to configure, customize, and maintain Odoo for your business&apos;s unique needs."
+              description: "Your administrators learn to configure, customize, and maintain Odoo for your specific workflows and reporting needs."
             },
             {
               icon: FileText,

--- a/app/services/tuning/page.tsx
+++ b/app/services/tuning/page.tsx
@@ -47,7 +47,7 @@ export default function TuningService() {
               <ul className="space-y-2 text-muted-foreground">
                 <li>• Advanced Accrual Time-Off Module: Simplify and customize accruals to match your policies.</li>
                 <li>• Time-Off Credit Management: Ensure accurate tracking and adjustments.</li>
-                <li>• Multi-Currency Contracts, Rates & Cost: Seamlessly manage international teams with built-in currency support.</li>
+                <li>• Multi-Currency Contracts, Rates & Cost: Manage international teams with built-in currency support.</li>
               </ul>
             </CardContent>
           </Card>
@@ -119,7 +119,7 @@ export default function TuningService() {
             },
             {
               title: "Implementation",
-              description: "We implement changes seamlessly to minimize disruption."
+              description: "We implement changes incrementally to minimize disruption."
             },
             {
               title: "Support",


### PR DESCRIPTION
## Summary

Replace 11 instances of banned vocabulary (per `brand/voice.md`) in service page detail sections:

- **seamless/seamlessly** (8) → "smooth", "without interruption", "incrementally", or removed
- **empower** (2) → "help", "your administrators learn"
- **tailored solutions** (1) → "configurations built to match"

5 files changed, all in `app/services/`.

## Verification

- `grep -ri "seamless\|empower\|tailored solution" app/services/` returns zero hits
- `npm run build` passes

Resolves: corporatehub/hq#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)